### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -15,14 +15,8 @@
         "{workspaceRoot}/eslint.config.js"
       ]
     },
-    "@nx/vite:test": {
-      "cache": true,
-      "inputs": ["default", "^production"]
-    },
-    "e2e": {
-      "cache": true,
-      "inputs": ["default", "^production"]
-    }
+    "@nx/vite:test": { "cache": true, "inputs": ["default", "^production"] },
+    "e2e": { "cache": true, "inputs": ["default", "^production"] }
   },
   "namedInputs": {
     "default": ["{projectRoot}/**/*", "sharedGlobals"],
@@ -35,6 +29,6 @@
     ],
     "sharedGlobals": []
   },
-  "nxCloudAccessToken": "NzhiZDgxODktNzA2MS00Yjc5LWFlNTEtN2M4Nzg4N2FmYmNjfHJlYWQtd3JpdGU=",
+  "nxCloudAccessToken": "OTA3N2Y4NTUtZThiYi00YTBhLTg0Y2QtMTRjYWM0NGE5MTNifHJlYWQtd3JpdGU=",
   "nxCloudUrl": "https://staging.nx.app"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 

This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.

You can access your Nx Cloud workspace by going to 
https://cloud.nx.app/orgs/65fa9816f0f4957b204052e5/workspaces/664636e475b1c72a3021547b

**Note:** This commit attempts to maintain formatting of the nx.json, however you may need to correct formatting by running an nx format command and committing the changes.